### PR TITLE
renamed fromPath to byPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import org.zamedev.lib.DynamicExt;
 using org.zamedev.lib.DynamicTools;
 
 var node:DynamicExt = haxe.Json.parse('{"a":{"b":"c"},"stringval":"haxe","arrayval":["haxe","cool"],"intval":42,"floatval":24.42,"boolval":true}');
-trace(node.dynamicPath(["a", "b"])); // Returns "c"
+trace(node.byPath(["a", "b"])); // Returns "c"
 trace(node["stringval"].asString());
 trace(node["arrayval"].asArray());
 trace(node["intval"].asInt());

--- a/org/zamedev/lib/DynamicTools.hx
+++ b/org/zamedev/lib/DynamicTools.hx
@@ -69,7 +69,7 @@ class DynamicTools {
         }
     }
 
-    public static function dynamicPath(jsondynamic:DynamicExt, jsonPath:Array<Dynamic>):Null<Dynamic> {
+    public static function byPath(jsondynamic:DynamicExt, jsonPath:Array<Dynamic>):Null<DynamicExt> {
         /*
             finds an element in a nested map/json file with a given path.
         */


### PR DESCRIPTION
Get a deep nested value by just giving an array of strings,

example:
`var path = "class.subclass.subsubclass.element";
  trace(mydynamic.byPath(path.split("."))); // value of element
`